### PR TITLE
Change the device status handling when it is offline

### DIFF
--- a/pdunehd/__init__.py
+++ b/pdunehd/__init__.py
@@ -89,4 +89,4 @@ class DuneHDPlayer():
 		if r.status_code == 200:
 			return self.__parse_status(r.text)
 		else:
-			raise Exception("Unable to commucate with Dune HD")
+			return {}

--- a/pdunehd/__init__.py
+++ b/pdunehd/__init__.py
@@ -23,7 +23,7 @@ class DuneHDPlayer():
 
 	def pause(self):
 		return self.__change_playback_speed(PLAYBACK_SPEED_PAUSE)
-	
+
 	def ffwd(self):
 		return self.__change_playback_speed(PLAYBACK_SPEED_FFWD)
 
@@ -78,10 +78,13 @@ class DuneHDPlayer():
 
 	def __send_command(self, cmd, params = {}):
 		params["cmd"] = cmd
-		r = requests.get(
-			BASE_COMMAND_URL_FORMAT.format(self._address),
-			params = params
-			)
+		try:
+			r = requests.get(
+				BASE_COMMAND_URL_FORMAT.format(self._address),
+				params = params
+				)
+		except requests.exceptions.ConnectionError:
+			return {}
 
 		if r.status_code == 200:
 			return self.__parse_status(r.text)


### PR DESCRIPTION
Currently, when the device is offline, any attempt to update the status results in an exception `requests.exceptions.ConnectionError`.
This PR adds catching this exception for `requests.get` and changes the response when `status_code != 200`. The integration after the change that is being prepared will respond to the `state == {}` marking the player entity as `unavailable`.