### PR TITLE
Add requests timeout and remove update from init

### DIFF
--- a/pdunehd/__init__.py
+++ b/pdunehd/__init__.py
@@ -10,7 +10,7 @@ PLAYBACK_SPEED_RWD = -512
 
 STATE_PARSER = re.compile('.*name="(.*)" value="(.*)"')
 
-TIMEOUT = 10
+TIMEOUT = 5
 
 class DuneHDPlayer():
 	def __init__(self, address):

--- a/pdunehd/__init__.py
+++ b/pdunehd/__init__.py
@@ -10,6 +10,8 @@ PLAYBACK_SPEED_RWD = -512
 
 STATE_PARSER = re.compile('.*name="(.*)" value="(.*)"')
 
+TIMEOUT = 10
+
 class DuneHDPlayer():
 	def __init__(self, address):
 		self._address = address
@@ -81,9 +83,10 @@ class DuneHDPlayer():
 		try:
 			r = requests.get(
 				BASE_COMMAND_URL_FORMAT.format(self._address),
-				params = params
+				params = params,
+				timeout = TIMEOUT
 				)
-		except requests.exceptions.ConnectionError:
+		except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
 			return {}
 
 		if r.status_code == 200:

--- a/pdunehd/__init__.py
+++ b/pdunehd/__init__.py
@@ -15,7 +15,6 @@ TIMEOUT = 10
 class DuneHDPlayer():
 	def __init__(self, address):
 		self._address = address
-		self.update_state()
 
 	def launch_media_url(self, mediaUrl):
 		return self.__send_command('launch_media_url', {'media_url': mediaUrl})


### PR DESCRIPTION
This PR adds requests `timeout` (5 seconds) and removes `update` from `init`.

Without requests `timeout` we have in HA log warnings when device is offline:
```
2020-05-27 11:11:50 WARNING (MainThread) [homeassistant.helpers.entity] Update of media_player.dune_hd is taking over 10 seconds
```

With `update` during initialization, setup of integration in HA takes too long:
```
2020-05-27 11:10:05 WARNING (MainThread) [homeassistant.components.media_player] Setup of media_player platform dunehd is taking over 10 seconds.
```